### PR TITLE
Fix fn modifier being captured for function key hotkeys (F1-F20)

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -11,8 +11,18 @@ import '../services/settings_storage.dart';
 import '../services/update_service.dart';
 import '../widgets/pasteable_text_field.dart';
 
+// macOS virtual key codes for F1-F20 (Carbon/HIToolbox values).
+const _functionKeyCodes = <int>{
+  64, 79, 80, 90, 96, 97, 98, 99, 100, 101, 103, 105, 106, 107, 109, 111, 113, 118, 120, 122,
+};
+
 /// Formats a hotkey (keyCode + modifier flags) for display.
 String formatHotkeyDisplay(int keyCode, int flags) {
+  // macOS automatically sets the fn flag on function key events even without
+  // physically pressing Fn. Strip it for display so F12 shows as "F12" not "fn F12".
+  if (_functionKeyCodes.contains(keyCode)) {
+    flags &= ~0x800000;
+  }
   // Keep macOS modifier order consistent with menu item display.
   const modifierSymbols = <int, String>{
     0x40000: '⌃', // Control

--- a/macos/Runner/HotkeyManager.swift
+++ b/macos/Runner/HotkeyManager.swift
@@ -5,10 +5,26 @@ struct HotkeySpec {
     let keyCode: Int
     let flags: UInt64
 
+    /// macOS automatically sets maskSecondaryFn on function key events even when the user
+    /// hasn't physically pressed the Fn key (e.g. with "Use F1-F12 as standard function keys").
+    /// Strip it so F12 is treated as F12, not fn+F12.
+    static func isFunctionKeyCode(_ code: Int64) -> Bool {
+        // kVK_F1…F20 in decimal
+        let fnKeys: Set<Int64> = [64, 79, 80, 90, 96, 97, 98, 99, 100, 101, 103, 105, 106, 107, 109, 111, 113, 118, 120, 122]
+        return fnKeys.contains(code)
+    }
+
     func matches(keyCode: Int64, flags: CGEventFlags) -> Bool {
         guard keyCode == self.keyCode else { return false }
         let mask: CGEventFlags = [.maskShift, .maskControl, .maskAlternate, .maskCommand, .maskSecondaryFn]
-        return (flags.intersection(mask).rawValue) == UInt64(self.flags)
+        var effectiveFlags = flags.intersection(mask).rawValue
+        var storedFlags = UInt64(self.flags)
+        if HotkeySpec.isFunctionKeyCode(keyCode) {
+            let fnMask = CGEventFlags.maskSecondaryFn.rawValue
+            effectiveFlags &= ~fnMask
+            storedFlags &= ~fnMask
+        }
+        return effectiveFlags == storedFlags
     }
 }
 
@@ -101,7 +117,11 @@ class HotkeyManager {
         if let capture = onCaptureNextKey {
             if type == .keyDown {
                 let mask: CGEventFlags = [.maskShift, .maskControl, .maskAlternate, .maskCommand, .maskSecondaryFn]
-                let flagsValue = flags.intersection(mask).rawValue
+                var flagsValue = flags.intersection(mask).rawValue
+                // Strip fn flag for function keys — macOS sets it automatically
+                if HotkeySpec.isFunctionKeyCode(keyCode) {
+                    flagsValue &= ~CGEventFlags.maskSecondaryFn.rawValue
+                }
                 DispatchQueue.main.async { capture(Int(keyCode), flagsValue) }
                 onCaptureNextKey = nil
                 return nil


### PR DESCRIPTION
## Summary

Fixes a regression where pressing F12 (or any F-key) was recorded as **fn F12** instead of just **F12**, even when the user had not physically pressed the Fn key.

- macOS automatically sets the `maskSecondaryFn` flag on CGEvents for function key presses when "Use F1–F12 as standard function keys" is enabled in System Settings — the app was incorrectly treating this as an explicit Fn modifier
- Strip `maskSecondaryFn` during **capture** so newly recorded function key hotkeys are stored cleanly
- Strip it during **matching** (on both stored flags and incoming event flags) so existing configs previously saved as "fn F12" continue to fire correctly
- Strip it in the Flutter **display** function so old stored configs no longer show "fn F12" in the UI

Closes https://github.com/Matinrahimik/open_yapper/issues/13

## Files changed

- `macos/Runner/HotkeyManager.swift` — `isFunctionKeyCode()` helper, capture fix, `HotkeySpec.matches` fix
- `lib/screens/settings_screen.dart` — `formatHotkeyDisplay` display fix

## Test plan

- [ ] Go to Settings → Global Hotkeys → Hold to record
- [ ] Click to remap, press F12 — should display **F12**, not **fn F12**
- [ ] Verify the hotkey fires correctly when pressing F12 during recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)