### PR TITLE
Add Gemini 3.1 Flash Lite Preview model and align labels with AI Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Stop typing, start talking. Speak into your mic, and Open Yapper transcribes you
 - **Dictionary memory** — Manage Corrections, Frequent Terms, and Suggestions with enable/disable controls
 - **User info aliases** — Save personal fields (email, phone, links, etc.) so phrases like "my email" auto-expand
 - **Phrase expansion pipeline** — Expands user aliases + dictionary replacements before pasting
-- **Model selection** — Choose between Gemini Flash Lite Latest (default) and Gemini Flash Latest
+- **Model selection** — Choose between Gemini Flash-Lite Latest (default), Gemini Flash Latest, and Gemini 3.1 Flash Lite Preview
 - **Per-app customization** — Configure tone + advanced custom prompt per app (Default + app-specific overrides)
 - **Global hotkeys** — Configure start, stop, and hold-to-record hotkeys (all independently editable)
 - **History & stats** — Browse past recordings, copy text, and see usage stats
@@ -231,6 +231,7 @@ Open Yapper can treat spoken formatting requests as instructions and shape outpu
 - In **Settings > Model Selection**, pick your Gemini model:
   - `gemini-flash-lite-latest` (default, lower cost)
   - `gemini-flash-latest` (higher quality, higher cost)
+  - `gemini-3.1-flash-lite-preview` (latest preview model)
 - The selected model is used for all new recordings until changed
 
 ### Settings (Current)

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -375,9 +375,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     await saveGeminiModel(model);
     if (!mounted) return;
     setState(() => _selectedModel = model);
-    final modelLabel = model == geminiFlashLatestModel
-        ? 'Flash latest'
-        : 'Flash lite latest';
+    final modelLabel = switch (model) {
+      geminiFlashLatestModel => 'Gemini Flash Latest',
+      gemini31FlashLitePreviewModel => 'Gemini 3.1 Flash Lite Preview',
+      _ => 'Gemini Flash-Lite Latest',
+    };
     ScaffoldMessenger.of(
       context,
     ).showSnackBar(SnackBar(content: Text('Model set to $modelLabel')));
@@ -627,11 +629,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     items: const [
                       DropdownMenuItem<String>(
                         value: geminiFlashLiteLatestModel,
-                        child: Text('Flash lite latest (default)'),
+                        child: Text('Gemini Flash-Lite Latest (default)'),
                       ),
                       DropdownMenuItem<String>(
                         value: geminiFlashLatestModel,
-                        child: Text('Flash latest'),
+                        child: Text('Gemini Flash Latest'),
+                      ),
+                      DropdownMenuItem<String>(
+                        value: gemini31FlashLitePreviewModel,
+                        child: Text('Gemini 3.1 Flash Lite Preview'),
                       ),
                     ],
                     onChanged: (value) {

--- a/lib/services/settings_storage.dart
+++ b/lib/services/settings_storage.dart
@@ -23,10 +23,12 @@ const _dismissedUpdateVersionKey = 'dismissed_update_version';
 
 const geminiFlashLatestModel = 'gemini-flash-latest';
 const geminiFlashLiteLatestModel = 'gemini-flash-lite-latest';
+const gemini31FlashLitePreviewModel = 'gemini-3.1-flash-lite-preview';
 const defaultGeminiModel = geminiFlashLiteLatestModel;
 const supportedGeminiModels = <String>{
   geminiFlashLatestModel,
   geminiFlashLiteLatestModel,
+  gemini31FlashLitePreviewModel,
 };
 
 /// Hotkey configuration for global shortcuts.


### PR DESCRIPTION
## Summary

- **New model option**: adds `gemini-3.1-flash-lite-preview` as a selectable Gemini model in Settings, giving users access to the latest preview model
- **Label alignment with Google AI Studio**: the existing model labels were renamed to match how Google AI Studio presents them, making it easier for users to cross-reference between the app and studio.google.com:
  - `Flash lite latest (default)` → `Gemini Flash-Lite Latest (default)`
  - `Flash latest` → `Gemini Flash Latest`
  - New: `Gemini 3.1 Flash Lite Preview`

<img width="360" height="183" alt="image" src="https://github.com/user-attachments/assets/b7ead38b-f013-4657-a33b-4c15fec50203" />

aistudio.google.com UI
<img width="533" height="207" alt="image" src="https://github.com/user-attachments/assets/920e6c24-0285-43a3-b934-2f5c7b00302c" />
<img width="529" height="366" alt="image" src="https://github.com/user-attachments/assets/0893a0fb-a244-49a7-9acb-f50295067669" />


## Files changed

- `lib/services/settings_storage.dart` — added `gemini31FlashLitePreviewModel` constant and included it in `supportedGeminiModels`
- `lib/screens/settings_screen.dart` — added new dropdown item, updated all labels to match AI Studio naming

## Test plan

- [ ] Open Settings → Gemini model dropdown
- [ ] Verify three options appear with updated labels
- [ ] Select "Gemini 3.1 Flash Lite Preview" and confirm snackbar shows the correct label
- [ ] Verify model is persisted after app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)